### PR TITLE
Added Public transport to Levi nine Github page

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -39,7 +39,15 @@
       <div class="projects">
         <li class="repo">
           <h3>
-            <a href="#">Project 1</a>
+            <a href="https://github.com/levinine/public-transport">Public transport</a>
+          </h3>
+          <div class="description">
+              <p>Open source public transport planner</p>
+          </div>
+        </li>
+        <!-- <li class="repo">
+          <h3>
+            <a href="#">Project 2</a>
           </h3>
           <div class="description">
               <p>Short description</p>
@@ -47,20 +55,12 @@
         </li>
         <li class="repo">
             <h3>
-              <a href="#">Project 2</a>
+              <a href="#">Project 3</a>
             </h3>
             <div class="description">
                 <p>Short description</p>
             </div>
-          </li>
-          <li class="repo">
-              <h3>
-                <a href="#">Project 3</a>
-              </h3>
-              <div class="description">
-                  <p>Short description</p>
-              </div>
-          </li>
+        </li> -->
       </div>
       <footer class="site-footer">       
           <span class="site-footer-owner"><a href="http://github.com/levinine/levinine.github.io">levinine.github.io</a> is maintained by <a href="http://github.com/levinine">levinine</a>.</span>


### PR DESCRIPTION
There is a generic template at levinine.github.io with dummy list of projects. This PR will list public-transport as the only project 